### PR TITLE
Animania compat

### DIFF
--- a/src/main/java/com/corosus/desirepaths/EventHandlerForge.java
+++ b/src/main/java/com/corosus/desirepaths/EventHandlerForge.java
@@ -1,20 +1,15 @@
 package com.corosus.desirepaths;
 
-import CoroUtil.ai.BehaviorModifier;
 import CoroUtil.forge.CULog;
 
-import com.animania.common.entities.sheep.EntityAnimaniaSheep;
 import com.corosus.desirepaths.ai.EntityAIEatGrassExtended;
 import com.corosus.desirepaths.block.BlockGrassWorn;
 import com.corosus.desirepaths.config.ConfigDesirePaths;
 import com.corosus.desirepaths.util.UtilEntityBuffsInstances;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.EntityAIEatGrass;
-import net.minecraft.entity.ai.EntityAIMoveIndoors;
-import net.minecraft.entity.ai.EntityAITasks;
 import net.minecraft.entity.passive.EntitySheep;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
@@ -26,14 +21,24 @@ import CoroUtil.util.Vec3;
 
 public class EventHandlerForge {
 
+	private static Class<?> animaniaSheepClass;
+
+	static {
+		try {
+			animaniaSheepClass = Loader.isModLoaded("animania") ? Class.forName("com.animania.common.entities.sheep.EntityAnimaniaSheep") : null;
+		} catch (ClassNotFoundException e) {
+			CULog.err("ERROR getting animania base sheep class, mod might have changed it, needs updating in DesirePaths");
+			e.printStackTrace();
+		}
+	}
+
 	@SubscribeEvent
 	public void onEntityCreatedOrLoaded(EntityJoinWorldEvent event) {
 		if (event.getEntity().world.isRemote) return;
 
-		if (event.getEntity() instanceof EntitySheep && !(Loader.isModLoaded("animania") && event.getEntity() instanceof EntityAnimaniaSheep)) {
+		if (event.getEntity() instanceof EntitySheep && !(animaniaSheepClass != null && animaniaSheepClass.isAssignableFrom(event.getEntity().getClass()))) {
 			EntitySheep ent = (EntitySheep) event.getEntity();
 
-			
 			CULog.dbg("replacing EntityAIEatGrass with our extended version");
 			EntityAIEatGrassExtended task = new EntityAIEatGrassExtended(ent);
 			UtilEntityBuffsInstances.replaceTaskIfMissing(ent, EntityAIEatGrass.class, task);

--- a/src/main/java/com/corosus/desirepaths/EventHandlerForge.java
+++ b/src/main/java/com/corosus/desirepaths/EventHandlerForge.java
@@ -2,6 +2,8 @@ package com.corosus.desirepaths;
 
 import CoroUtil.ai.BehaviorModifier;
 import CoroUtil.forge.CULog;
+
+import com.animania.common.entities.sheep.EntityAnimaniaSheep;
 import com.corosus.desirepaths.ai.EntityAIEatGrassExtended;
 import com.corosus.desirepaths.block.BlockGrassWorn;
 import com.corosus.desirepaths.config.ConfigDesirePaths;
@@ -17,6 +19,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import CoroUtil.util.CoroUtilPlayer;
 import CoroUtil.util.Vec3;
@@ -27,9 +30,10 @@ public class EventHandlerForge {
 	public void onEntityCreatedOrLoaded(EntityJoinWorldEvent event) {
 		if (event.getEntity().world.isRemote) return;
 
-		if (event.getEntity() instanceof EntitySheep) {
+		if (event.getEntity() instanceof EntitySheep && !(Loader.isModLoaded("desirepaths") && event.getEntity() instanceof EntityAnimaniaSheep)) {
 			EntitySheep ent = (EntitySheep) event.getEntity();
 
+			
 			CULog.dbg("replacing EntityAIEatGrass with our extended version");
 			EntityAIEatGrassExtended task = new EntityAIEatGrassExtended(ent);
 			UtilEntityBuffsInstances.replaceTaskIfMissing(ent, EntityAIEatGrass.class, task, 5);

--- a/src/main/java/com/corosus/desirepaths/EventHandlerForge.java
+++ b/src/main/java/com/corosus/desirepaths/EventHandlerForge.java
@@ -30,7 +30,7 @@ public class EventHandlerForge {
 	public void onEntityCreatedOrLoaded(EntityJoinWorldEvent event) {
 		if (event.getEntity().world.isRemote) return;
 
-		if (event.getEntity() instanceof EntitySheep && !(Loader.isModLoaded("desirepaths") && event.getEntity() instanceof EntityAnimaniaSheep)) {
+		if (event.getEntity() instanceof EntitySheep && !(Loader.isModLoaded("animania") && event.getEntity() instanceof EntityAnimaniaSheep)) {
 			EntitySheep ent = (EntitySheep) event.getEntity();
 
 			

--- a/src/main/java/com/corosus/desirepaths/EventHandlerForge.java
+++ b/src/main/java/com/corosus/desirepaths/EventHandlerForge.java
@@ -36,7 +36,7 @@ public class EventHandlerForge {
 			
 			CULog.dbg("replacing EntityAIEatGrass with our extended version");
 			EntityAIEatGrassExtended task = new EntityAIEatGrassExtended(ent);
-			UtilEntityBuffsInstances.replaceTaskIfMissing(ent, EntityAIEatGrass.class, task, 5);
+			UtilEntityBuffsInstances.replaceTaskIfMissing(ent, EntityAIEatGrass.class, task);
 
 			ent.entityAIEatGrass = task;
 		}

--- a/src/main/java/com/corosus/desirepaths/util/UtilEntityBuffsInstances.java
+++ b/src/main/java/com/corosus/desirepaths/util/UtilEntityBuffsInstances.java
@@ -5,13 +5,12 @@ import java.util.Iterator;
 import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.ai.EntityAIBase;
 import net.minecraft.entity.ai.EntityAITasks;
-import net.minecraft.entity.ai.EntityAITasks.EntityAITaskEntry;
 
 public class UtilEntityBuffsInstances {
 
     public static boolean replaceTaskIfMissing(EntityCreature ent, Class taskToReplace, EntityAIBase taskToReplaceWith) {
         int priority = Integer.MIN_VALUE;
-        for (Iterator<EntityAITaskEntry> iter = ent.tasks.taskEntries.iterator(); iter.hasNext(); ) {
+        for (Iterator<EntityAITasks.EntityAITaskEntry> iter = ent.tasks.taskEntries.iterator(); iter.hasNext(); ) {
             EntityAITasks.EntityAITaskEntry entry = iter.next();
             if (taskToReplace.isAssignableFrom(entry.action.getClass())) {
             	priority = entry.priority;

--- a/src/main/java/com/corosus/desirepaths/util/UtilEntityBuffsInstances.java
+++ b/src/main/java/com/corosus/desirepaths/util/UtilEntityBuffsInstances.java
@@ -1,28 +1,31 @@
 package com.corosus.desirepaths.util;
 
+import java.util.Iterator;
+
 import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.ai.EntityAIBase;
 import net.minecraft.entity.ai.EntityAITasks;
+import net.minecraft.entity.ai.EntityAITasks.EntityAITaskEntry;
 
 public class UtilEntityBuffsInstances {
 
-    public static boolean replaceTaskIfMissing(EntityCreature ent, Class taskToReplace, EntityAIBase taskToReplaceWith, int priorityOfTask) {
-        EntityAITasks.EntityAITaskEntry foundTask = null;
-        for (Object entry2 : ent.tasks.taskEntries) {
-            EntityAITasks.EntityAITaskEntry entry = (EntityAITasks.EntityAITaskEntry) entry2;
+    public static boolean replaceTaskIfMissing(EntityCreature ent, Class taskToReplace, EntityAIBase taskToReplaceWith) {
+        int priority = Integer.MIN_VALUE;
+        for (Iterator<EntityAITaskEntry> iter = ent.tasks.taskEntries.iterator(); iter.hasNext(); ) {
+            EntityAITasks.EntityAITaskEntry entry = iter.next();
             if (taskToReplace.isAssignableFrom(entry.action.getClass())) {
-                foundTask = entry;
+            	priority = entry.priority;
+                iter.remove();
                 break;
             }
         }
 
-        if (foundTask != null) {
-            ent.tasks.taskEntries.remove(foundTask);
-
-            addTask(ent, taskToReplaceWith, priorityOfTask);
+        if (priority != Integer.MIN_VALUE) {
+            addTask(ent, taskToReplaceWith, priority);
+            return true;
         }
 
-        return foundTask != null;
+        return false;
 
     }
 


### PR DESCRIPTION
This stops animania sheeps from getting their AI exchanged. Animania already handles DesirePath compat for their grass eating entities, so that's fine.